### PR TITLE
Reference ./data/load in the parent directory

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -64,6 +64,7 @@ object Settings extends Build {
     parallelExecution in IntegrationTest := false,
     testOptions in Test ++= testOptionSettings,
     testOptions in IntegrationTest ++= testOptionSettings,
+    baseDirectory in Test := baseDirectory.value.getParentFile(),
     fork in Test := true,
     fork in IntegrationTest := true,
     (compile in IntegrationTest) <<= (compile in Test, compile in IntegrationTest) map { (_, c) => c },


### PR DESCRIPTION
Tests fail because working directory references the subproject