### PR TITLE
reflect loaded files

### DIFF
--- a/killrweather-clients/src/main/scala/com/datastax/killrweather/DataFeedApp.scala
+++ b/killrweather-clients/src/main/scala/com/datastax/killrweather/DataFeedApp.scala
@@ -123,7 +123,7 @@ class DynamicDataFeedActor(cluster: Cluster) extends Actor with ActorLogging wit
       toFiles(headers) map { files =>
         log.info(s"Received {}", files.mkString)
         context.actorOf(Props(new FileFeedActor(cluster))) ! FileStreamEnvelope(files:_*)
-        HttpResponse(200, entity = HttpEntity(MediaTypes.`text/html`, s"POST [$entity] successful."))
+        HttpResponse(200, entity = HttpEntity(MediaTypes.`text/html`, s"POST [${files.mkString}] successful."))
       } getOrElse
         HttpResponse(404, entity = s"Unknown resource '$entity'")
 


### PR DESCRIPTION
The POST response did not provide any useful information, other than the HTTP code.

Listing the names of the files that were actually located provides positive feedback.