### PR TITLE
Explicitly listen on 127.0.0.1 so the default of InetAddress.getLocalHos...

### DIFF
--- a/killrweather-app/src/main/resources/reference.conf
+++ b/killrweather-app/src/main/resources/reference.conf
@@ -116,7 +116,10 @@ akka {
 
   remote {
     log-remote-lifecycle-events = off
-    netty.tcp.port = 2550
+    netty.tcp {
+      port = 2550
+      hostname = "127.0.0.1"
+    }
   }
 
   actor {

--- a/killrweather-clients/src/main/resources/reference.conf
+++ b/killrweather-clients/src/main/resources/reference.conf
@@ -13,7 +13,10 @@ akka {
 
   remote {
     log-remote-lifecycle-events = off
-    netty.tcp.port = 0
+    netty.tcp {
+      port = 0
+      hostname = "127.0.0.1"
+    }
   }
 
   actor {


### PR DESCRIPTION
...t.getHostAddress doesn't pick something stupid

This didn't work by default on my crazy home network and imagine may break on some crazy conference WiFi.