### PR TITLE
FutureT: @uncheckedVariance

### DIFF
--- a/killrweather-app/src/main/scala/com/datastax/killrweather/syntax/FutureSyntax.scala
+++ b/killrweather-app/src/main/scala/com/datastax/killrweather/syntax/FutureSyntax.scala
@@ -4,9 +4,10 @@ package object future {
   import scala.concurrent._
   import scalaz._
   import scalaz.contrib.std.scalaFuture._
-
-  type FutureT[+A] = EitherT[Future, Throwable, A]
-
+  import scala.annotation.unchecked.uncheckedVariance
+  
+  type FutureT[+A] = EitherT[Future, Throwable, A @uncheckedVariance]
+  
   /** Avoid the need to handle Future error/timeout via callbacks by transforming the value into an EitherT, i.e.,
     * EitherT[Future, Throwable, A] === Future[Throwable \/ A]. */
   implicit class ScalaFutureOps[A](future: Future[A])(implicit context: ExecutionContext) {


### PR DESCRIPTION
To avoid such error (using Scala 2.10.6):

[info] Compiling 1 Scala source to …
/killrweather/killrweather-app/target/scala-2.10/classes...
[error] …
/killrweather/killrweather-app/src/main/scala/com/datastax/killrweather/
syntax/FutureSyntax.scala:8: covariant type A occurs in invariant
position in type
[+A]scalaz.EitherT[scala.concurrent.Future,Throwable,A] of type FutureT
[error]   type FutureT[+A] = EitherT[Future, Throwable, A]
[error]        ^
[error] one error found
[error] (app/compile:compile) Compilation failed