### PR TITLE
update sbt-assembly version

### DIFF
--- a/project/KillrWeatherBuild.scala
+++ b/project/KillrWeatherBuild.scala
@@ -69,6 +69,7 @@ object Dependencies {
 
     def embeddedExclusions: ModuleID =
       module.log4jExclude.excludeAll(ExclusionRule("org.apache.spark"))
+     .excludeAll(ExclusionRule("org.slf4j"))
      .excludeAll(ExclusionRule("com.typesafe"))
      .excludeAll(ExclusionRule("org.apache.cassandra"))
      .excludeAll(ExclusionRule("com.datastax.cassandra"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.3.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.2")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
 
 addSbtPlugin("com.scalapenos" % "sbt-prompt" % "0.2.1")
 


### PR DESCRIPTION
with the old version of the  sbt-assembly plugin i got the following error
```bash
berndzuther@MacBook-Pro ~/development/killrweather (master●)$ sbt assembly
[info] Loading project definition from /Users/berndzuther/development/killrweather/project
[info] Updating {file:/Users/berndzuther/development/killrweather/project/}killrweather-build...
Waiting for lock on /Users/berndzuther/.ivy2/.sbt.ivy.lock to be available...
[info] Resolving org.fusesource.jansi#jansi;1.4 ...
[info] Done updating.
[warn] There may be incompatibilities among your library dependencies.
[warn] Here are some of the libraries that were evicted:
[warn]  * com.typesafe.sbt:sbt-git:0.6.2 -> 0.6.4
[warn] Run 'evicted' to see detailed eviction warnings
[info] Compiling 3 Scala sources to /Users/berndzuther/development/killrweather/project/target/scala-2.10/sbt-0.13/classes...
[warn] there were 6 feature warning(s); re-run with -feature for details
[warn] one warning found
[info] Set current project to KillrWeather (in build file:/Users/berndzuther/development/killrweather/)
[error] Not a valid command: assembly
[error] Not a valid project ID: assembly
[error] Expected ':' (if selecting a configuration)
[error] Not a valid key: assembly
[error] assembly
[error] 
```