### PR TITLE
Fix client app to actually do something

### DIFF
--- a/killrweather-clients/src/main/scala/com/datastax/killrweather/KillrWeatherClientApp.scala
+++ b/killrweather-clients/src/main/scala/com/datastax/killrweather/KillrWeatherClientApp.scala
@@ -47,12 +47,12 @@ final class ApiNodeGuardian extends ClusterAwareNodeGuardian with ClientHelper {
 
   var task: Option[Cancellable] = None
 
- /* override def preStart(): Unit = {
+  override def preStart(): Unit = {
     super.preStart()
-    cluster.join(base)
-    cluster.joinSeedNodes(Vector(base))
+    cluster.join(cluster.selfAddress)
+    cluster.joinSeedNodes(Vector(cluster.selfAddress))
   }
-*/
+
   Cluster(context.system).registerOnMemberUp {
     task = Some(context.system.scheduler.schedule(Duration.Zero, 2.seconds) {
       api ! Event.QueryTask


### PR DESCRIPTION
Fixes #46 by by uncommenting the method `preStart` in `ApiNodeGuardian`. With this change, the client application actually works.